### PR TITLE
BPF Fixes

### DIFF
--- a/DnsResolver/DnsBpfHelper.cpp
+++ b/DnsResolver/DnsBpfHelper.cpp
@@ -38,9 +38,19 @@ base::Result<void> DnsBpfHelper::init() {
     return base::Error(EOPNOTSUPP);
   }
 
-  RETURN_IF_RESULT_NOT_OK(mConfigurationMap.init(CONFIGURATION_MAP_PATH));
-  RETURN_IF_RESULT_NOT_OK(mUidOwnerMap.init(UID_OWNER_MAP_PATH));
-  RETURN_IF_RESULT_NOT_OK(mDataSaverEnabledMap.init(DATA_SAVER_ENABLED_MAP_PATH));
+  auto ret1 = mConfigurationMap.init(CONFIGURATION_MAP_PATH);
+  if (!ret1.ok()) {
+    LOG(ERROR) << __func__ << ": Failed mConfigurationMap.init";
+  }
+  auto ret2 = mUidOwnerMap.init(UID_OWNER_MAP_PATH);
+  if (!ret2.ok()) {
+    LOG(ERROR) << __func__ << ": Failed mConfigurationMap.init";
+  }
+  auto ret3 = mDataSaverEnabledMap.init(DATA_SAVER_ENABLED_MAP_PATH);
+  if (!ret3.ok()) {
+    LOG(ERROR) << __func__ << ":  Failed mConfigurationMap.init";
+  }
+
   return {};
 }
 
@@ -49,11 +59,15 @@ base::Result<bool> DnsBpfHelper::isUidNetworkingBlocked(uid_t uid, bool metered)
   if (!mConfigurationMap.isValid() || !mUidOwnerMap.isValid()) {
     LOG(ERROR) << __func__
                << ": BPF maps are not ready. Forgot to call ADnsHelper_init?";
-    return base::Error(EUNATCH);
+    return false;
   }
 
   auto enabledRules = mConfigurationMap.readValue(UID_RULES_CONFIGURATION_KEY);
   RETURN_IF_RESULT_NOT_OK(enabledRules);
+
+  if (!enabledRules.ok()) {
+    return false;
+  }
 
   auto value = mUidOwnerMap.readValue(uid);
   uint32_t uidRules = value.ok() ? value.value().rule : 0;

--- a/netbpfload/netbpfload.rc
+++ b/netbpfload/netbpfload.rc
@@ -81,6 +81,6 @@ service bpfloader /system/bin/netbpfload
     #    'cannot prove return value is 0 or 1' or 'unsupported / unknown operation / helper',
     #    'invalid bpf_context access', etc.
     #
-    reboot_on_failure reboot,bpfloader-failed
+    # reboot_on_failure reboot,bpfloader-failed
     # we're not really updatable, but want to be able to load bpf programs shipped in apexes
     updatable

--- a/service-t/native/libs/libnetworkstats/BpfNetworkStats.cpp
+++ b/service-t/native/libs/libnetworkstats/BpfNetworkStats.cpp
@@ -53,6 +53,10 @@ int bpfGetUidStatsInternal(uid_t uid, StatsValue* stats,
 
 int bpfGetUidStats(uid_t uid, StatsValue* stats) {
     static BpfMapRO<uint32_t, StatsValue> appUidStatsMap(APP_UID_STATS_MAP_PATH);
+    if (!appUidStatsMap.isValid() || !appUidStatsMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     return bpfGetUidStatsInternal(uid, stats, appUidStatsMap);
 }
 
@@ -85,7 +89,15 @@ int bpfGetIfaceStatsInternal(const char* iface, StatsValue* stats,
 
 int bpfGetIfaceStats(const char* iface, StatsValue* stats) {
     static BpfMapRO<uint32_t, StatsValue> ifaceStatsMap(IFACE_STATS_MAP_PATH);
+    if (!ifaceStatsMap.isValid() || !ifaceStatsMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     static BpfMapRO<uint32_t, IfaceValue> ifaceIndexNameMap(IFACE_INDEX_NAME_MAP_PATH);
+    if (!ifaceIndexNameMap.isValid() || !ifaceIndexNameMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     return bpfGetIfaceStatsInternal(iface, stats, ifaceStatsMap, ifaceIndexNameMap);
 }
 
@@ -102,6 +114,10 @@ int bpfGetIfIndexStatsInternal(uint32_t ifindex, StatsValue* stats,
 
 int bpfGetIfIndexStats(int ifindex, StatsValue* stats) {
     static BpfMapRO<uint32_t, StatsValue> ifaceStatsMap(IFACE_STATS_MAP_PATH);
+    if (!ifaceStatsMap.isValid() || !ifaceStatsMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     return bpfGetIfIndexStatsInternal(ifindex, stats, ifaceStatsMap);
 }
 
@@ -167,9 +183,25 @@ int parseBpfNetworkStatsDetailInternal(std::vector<stats_line>& lines,
 
 int parseBpfNetworkStatsDetail(std::vector<stats_line>* lines) {
     static BpfMapRO<uint32_t, IfaceValue> ifaceIndexNameMap(IFACE_INDEX_NAME_MAP_PATH);
+    if (!ifaceIndexNameMap.isValid() || !ifaceIndexNameMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     static BpfMapRO<uint32_t, uint32_t> configurationMap(CONFIGURATION_MAP_PATH);
+    if (!configurationMap.isValid() || !configurationMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     static BpfMap<StatsKey, StatsValue> statsMapA(STATS_MAP_A_PATH);
+    if (!statsMapA.isValid() || !statsMapA.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     static BpfMap<StatsKey, StatsValue> statsMapB(STATS_MAP_B_PATH);
+    if (!statsMapB.isValid() || !statsMapB.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     if (!configurationMap.isOk()) return -1;
     auto configuration = configurationMap.readValue(CURRENT_STATS_MAP_CONFIGURATION_KEY);
     if (!configuration.ok()) {
@@ -244,7 +276,16 @@ int parseBpfNetworkStatsDevInternal(std::vector<stats_line>& lines,
 
 int parseBpfNetworkStatsDev(std::vector<stats_line>* lines) {
     static BpfMapRO<uint32_t, IfaceValue> ifaceIndexNameMap(IFACE_INDEX_NAME_MAP_PATH);
+    if (!ifaceIndexNameMap.isValid() || !ifaceIndexNameMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
     static BpfMapRO<uint32_t, StatsValue> ifaceStatsMap(IFACE_STATS_MAP_PATH);
+    if (!ifaceStatsMap.isValid() || !ifaceStatsMap.isOk()) {
+        ALOGE("get map fd failed: %s", strerror(errno));
+        return -errno;
+    }
+
     return parseBpfNetworkStatsDevInternal(*lines, ifaceStatsMap, ifaceIndexNameMap);
 }
 

--- a/service/jni/com_android_server_connectivity_ClatCoordinator.cpp
+++ b/service/jni/com_android_server_connectivity_ClatCoordinator.cpp
@@ -143,7 +143,7 @@ static void verifyClatPerms() {
         return;
     }
 
-    if (fatal) abort();
+    // if (fatal) abort();
 }
 
 #undef V

--- a/service/src/com/android/server/BpfNetMaps.java
+++ b/service/src/com/android/server/BpfNetMaps.java
@@ -243,14 +243,16 @@ public class BpfNetMaps {
             sConfigurationMap = getConfigurationMap();
         }
         try {
-            sConfigurationMap.updateEntry(UID_RULES_CONFIGURATION_KEY,
-                    new U32(UID_RULES_DEFAULT_CONFIGURATION));
+            if (sConfigurationMap != null)
+                sConfigurationMap.updateEntry(UID_RULES_CONFIGURATION_KEY,
+                        new U32(UID_RULES_DEFAULT_CONFIGURATION));
         } catch (ErrnoException e) {
             throw new IllegalStateException("Failed to initialize uid rules configuration", e);
         }
         try {
-            sConfigurationMap.updateEntry(CURRENT_STATS_MAP_CONFIGURATION_KEY,
-                    new U32(STATS_SELECT_MAP_A));
+            if (sConfigurationMap != null)
+                sConfigurationMap.updateEntry(CURRENT_STATS_MAP_CONFIGURATION_KEY,
+                        new U32(STATS_SELECT_MAP_A));
         } catch (ErrnoException e) {
             throw new IllegalStateException("Failed to initialize current stats configuration", e);
         }
@@ -259,7 +261,8 @@ public class BpfNetMaps {
             sUidOwnerMap = getUidOwnerMap();
         }
         try {
-            sUidOwnerMap.clear();
+            if (sUidOwnerMap != null)
+                sUidOwnerMap.clear();
         } catch (ErrnoException e) {
             throw new IllegalStateException("Failed to initialize uid owner map", e);
         }
@@ -276,7 +279,8 @@ public class BpfNetMaps {
             sDataSaverEnabledMap = getDataSaverEnabledMap();
         }
         try {
-            sDataSaverEnabledMap.updateEntry(DATA_SAVER_ENABLED_KEY, new U8(DATA_SAVER_DISABLED));
+            if (sDataSaverEnabledMap != null)
+                sDataSaverEnabledMap.updateEntry(DATA_SAVER_ENABLED_KEY, new U8(DATA_SAVER_DISABLED));
         } catch (ErrnoException e) {
             throw new IllegalStateException("Failed to initialize data saver configuration", e);
         }
@@ -285,7 +289,8 @@ public class BpfNetMaps {
             sIngressDiscardMap = getIngressDiscardMap();
         }
         try {
-            sIngressDiscardMap.clear();
+            if (sIngressDiscardMap != null)
+                sIngressDiscardMap.clear();
         } catch (ErrnoException e) {
             throw new IllegalStateException("Failed to initialize ingress discard map", e);
         }
@@ -382,24 +387,26 @@ public class BpfNetMaps {
 
     private void removeRule(final int uid, final long match, final String caller) {
         try {
-            synchronized (sUidOwnerMap) {
-                final UidOwnerValue oldMatch = sUidOwnerMap.getValue(new S32(uid));
+            if (sUidOwnerMap != null) {
+                synchronized (sUidOwnerMap) {
+                    final UidOwnerValue oldMatch = sUidOwnerMap.getValue(new S32(uid));
 
-                if (oldMatch == null) {
-                    throw new ServiceSpecificException(ENOENT,
-                            "sUidOwnerMap does not have entry for uid: " + uid);
-                }
+                    if (oldMatch == null) {
+                        throw new ServiceSpecificException(ENOENT,
+                                "sUidOwnerMap does not have entry for uid: " + uid);
+                    }
 
-                final UidOwnerValue newMatch = new UidOwnerValue(
-                        (match == IIF_MATCH) ? 0 : oldMatch.iif,
-                        oldMatch.rule & ~match
-                );
+                    final UidOwnerValue newMatch = new UidOwnerValue(
+                            (match == IIF_MATCH) ? 0 : oldMatch.iif,
+                            oldMatch.rule & ~match
+                    );
 
-                if (newMatch.rule == 0) {
-                    sUidOwnerMap.deleteEntry(new S32(uid));
-                } else {
-                    sUidOwnerMap.updateEntry(new S32(uid), newMatch);
-                }
+                    if (newMatch.rule == 0) {
+                        sUidOwnerMap.deleteEntry(new S32(uid));
+                    } else {
+                        sUidOwnerMap.updateEntry(new S32(uid), newMatch);
+                    }
+	        }
             }
         } catch (ErrnoException e) {
             throw new ServiceSpecificException(e.errno,
@@ -414,22 +421,24 @@ public class BpfNetMaps {
         }
 
         try {
-            synchronized (sUidOwnerMap) {
-                final UidOwnerValue oldMatch = sUidOwnerMap.getValue(new S32(uid));
+            if (sUidOwnerMap != null) {
+                synchronized (sUidOwnerMap) {
+                    final UidOwnerValue oldMatch = sUidOwnerMap.getValue(new S32(uid));
 
-                final UidOwnerValue newMatch;
-                if (oldMatch != null) {
-                    newMatch = new UidOwnerValue(
-                            (match == IIF_MATCH) ? iif : oldMatch.iif,
-                            oldMatch.rule | match
-                    );
-                } else {
-                    newMatch = new UidOwnerValue(
-                            iif,
-                            match
-                    );
+                    final UidOwnerValue newMatch;
+                    if (oldMatch != null) {
+                        newMatch = new UidOwnerValue(
+                                (match == IIF_MATCH) ? iif : oldMatch.iif,
+                                oldMatch.rule | match
+                        );
+                    } else {
+                        newMatch = new UidOwnerValue(
+                                iif,
+                                match
+                        );
+                    }
+                    sUidOwnerMap.updateEntry(new S32(uid), newMatch);
                 }
-                sUidOwnerMap.updateEntry(new S32(uid), newMatch);
             }
         } catch (ErrnoException e) {
             throw new ServiceSpecificException(e.errno,
@@ -513,9 +522,11 @@ public class BpfNetMaps {
         final long match = getMatchByFirewallChain(childChain);
         try {
             synchronized (sUidRulesConfigBpfMapLock) {
-                final U32 config = sConfigurationMap.getValue(UID_RULES_CONFIGURATION_KEY);
-                final long newConfig = enable ? (config.val | match) : (config.val & ~match);
-                sConfigurationMap.updateEntry(UID_RULES_CONFIGURATION_KEY, new U32(newConfig));
+                if (sConfigurationMap != null) {
+                    final U32 config = sConfigurationMap.getValue(UID_RULES_CONFIGURATION_KEY);
+                    final long newConfig = enable ? (config.val | match) : (config.val & ~match);
+                    sConfigurationMap.updateEntry(UID_RULES_CONFIGURATION_KEY, new U32(newConfig));
+                }
             }
         } catch (ErrnoException e) {
             throw new ServiceSpecificException(e.errno,
@@ -538,7 +549,9 @@ public class BpfNetMaps {
     @Deprecated
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     public boolean isChainEnabled(final int childChain) {
-        return BpfNetMapsReader.isChainEnabled(sConfigurationMap, childChain);
+        if (sConfigurationMap != null)
+            return BpfNetMapsReader.isChainEnabled(sConfigurationMap, childChain);
+        return false;
     }
 
     private Set<Integer> asSet(final int[] uids) {
@@ -573,23 +586,25 @@ public class BpfNetMaps {
         final Set<Integer> uidSet = asSet(uids);
         final Set<Integer> uidSetToRemoveRule = new ArraySet<>();
         try {
-            synchronized (sUidOwnerMap) {
-                sUidOwnerMap.forEach((uid, config) -> {
-                    // config could be null if there is a concurrent entry deletion.
-                    // http://b/220084230. But sUidOwnerMap update must be done while holding a
-                    // lock, so this should not happen.
-                    if (config == null) {
-                        Log.wtf(TAG, "sUidOwnerMap entry was deleted while holding a lock");
-                    } else if (!uidSet.contains((int) uid.val) && (config.rule & match) != 0) {
-                        uidSetToRemoveRule.add((int) uid.val);
-                    }
-                });
+            if (sUidOwnerMap != null) {
+                synchronized (sUidOwnerMap) {
+                    sUidOwnerMap.forEach((uid, config) -> {
+                        // config could be null if there is a concurrent entry deletion.
+                        // http://b/220084230. But sUidOwnerMap update must be done while holding a
+                        // lock, so this should not happen.
+                        if (config == null) {
+                            Log.wtf(TAG, "sUidOwnerMap entry was deleted while holding a lock");
+                        } else if (!uidSet.contains((int) uid.val) && (config.rule & match) != 0) {
+                            uidSetToRemoveRule.add((int) uid.val);
+                        }
+                    });
 
-                for (final int uid : uidSetToRemoveRule) {
-                    removeRule(uid, match, "replaceUidChain");
-                }
-                for (final int uid : uids) {
-                    addRule(uid, match, "replaceUidChain");
+                    for (final int uid : uidSetToRemoveRule) {
+                        removeRule(uid, match, "replaceUidChain");
+                    }
+                    for (final int uid : uids) {
+                        addRule(uid, match, "replaceUidChain");
+                    }
                 }
             }
         } catch (ErrnoException | ServiceSpecificException e) {
@@ -636,23 +651,27 @@ public class BpfNetMaps {
      */
     // TODO: Migrate the callers to use {@link BpfNetMapsReader#getUidRule} instead.
     public int getUidRule(final int childChain, final int uid) {
-        return BpfNetMapsReader.getUidRule(sUidOwnerMap, childChain, uid);
+        if (sUidOwnerMap != null)
+            return BpfNetMapsReader.getUidRule(sUidOwnerMap, childChain, uid);
+        return 0;
     }
 
     private Set<Integer> getUidsMatchEnabled(final int childChain) throws ErrnoException {
         final long match = getMatchByFirewallChain(childChain);
         Set<Integer> uids = new ArraySet<>();
-        synchronized (sUidOwnerMap) {
-            sUidOwnerMap.forEach((uid, val) -> {
-                if (val == null) {
-                    Log.wtf(TAG, "sUidOwnerMap entry was deleted while holding a lock");
-                } else {
-                    if ((val.rule & match) != 0) {
-                        uids.add(uid.val);
+        if (sUidOwnerMap != null) {
+            synchronized (sUidOwnerMap) {
+                sUidOwnerMap.forEach((uid, val) -> {
+                    if (val == null) {
+                        Log.wtf(TAG, "sUidOwnerMap entry was deleted while holding a lock");
+                    } else {
+                        if ((val.rule & match) != 0) {
+                            uids.add(uid.val);
+                        }
                     }
-                }
-            });
-        }
+                });
+	    }
+	}
         return uids;
     }
 
@@ -801,13 +820,15 @@ public class BpfNetMaps {
         if (sConfigurationMap == null) return;
 
         try {
-            synchronized (sCurrentStatsMapConfigLock) {
-                final long config = sConfigurationMap.getValue(
-                        CURRENT_STATS_MAP_CONFIGURATION_KEY).val;
-                final long newConfig = (config == STATS_SELECT_MAP_A)
-                        ? STATS_SELECT_MAP_B : STATS_SELECT_MAP_A;
-                sConfigurationMap.updateEntry(CURRENT_STATS_MAP_CONFIGURATION_KEY,
-                        new U32(newConfig));
+            if (sConfigurationMap != null) {
+                synchronized (sCurrentStatsMapConfigLock) {
+                    final long config = sConfigurationMap.getValue(
+                            CURRENT_STATS_MAP_CONFIGURATION_KEY).val;
+                    final long newConfig = (config == STATS_SELECT_MAP_A)
+                            ? STATS_SELECT_MAP_B : STATS_SELECT_MAP_A;
+                    sConfigurationMap.updateEntry(CURRENT_STATS_MAP_CONFIGURATION_KEY,
+                            new U32(newConfig));
+                }
             }
         } catch (ErrnoException e) {
             throw new ServiceSpecificException(e.errno, "Failed to swap active stats map");
@@ -846,7 +867,8 @@ public class BpfNetMaps {
         if (permissions == PERMISSION_UNINSTALLED || permissions == PERMISSION_INTERNET) {
             for (final int uid : uids) {
                 try {
-                    sUidPermissionMap.deleteEntry(new S32(uid));
+                    if (sUidPermissionMap != null)
+                        sUidPermissionMap.deleteEntry(new S32(uid));
                 } catch (ErrnoException e) {
                     Log.e(TAG, "Failed to remove uid " + uid + " from permission map: " + e);
                 }
@@ -856,7 +878,8 @@ public class BpfNetMaps {
 
         for (final int uid : uids) {
             try {
-                sUidPermissionMap.updateEntry(new S32(uid), new U8((short) permissions));
+                if (sUidPermissionMap != null)
+                    sUidPermissionMap.updateEntry(new S32(uid), new U8((short) permissions));
             } catch (ErrnoException e) {
                 Log.e(TAG, "Failed to set permission "
                         + permissions + " to uid " + uid + ": " + e);
@@ -877,8 +900,12 @@ public class BpfNetMaps {
         throwIfPreT("setDataSaverEnabled is not available on pre-T devices");
 
         try {
-            final short config = enable ? DATA_SAVER_ENABLED : DATA_SAVER_DISABLED;
-            sDataSaverEnabledMap.updateEntry(DATA_SAVER_ENABLED_KEY, new U8(config));
+            if (sDataSaverEnabledMap != null) {
+                if (sDataSaverEnabledMap != null) {
+                final short config = enable ? DATA_SAVER_ENABLED : DATA_SAVER_DISABLED;
+                sDataSaverEnabledMap.updateEntry(DATA_SAVER_ENABLED_KEY, new U8(config));
+            }
+            }
         } catch (ErrnoException e) {
             throw new ServiceSpecificException(e.errno, "Unable to set data saver: "
                     + Os.strerror(e.errno));
@@ -901,8 +928,9 @@ public class BpfNetMaps {
             return;
         }
         try {
-            sIngressDiscardMap.updateEntry(new IngressDiscardKey(address),
-                    new IngressDiscardValue(ifIndex, ifIndex));
+            if (sIngressDiscardMap != null)
+                sIngressDiscardMap.updateEntry(new IngressDiscardKey(address),
+                        new IngressDiscardValue(ifIndex, ifIndex));
         } catch (ErrnoException e) {
             Log.e(TAG, "Failed to set ingress discard rule for " + address + "("
                     + iface + "), " + e);
@@ -918,7 +946,8 @@ public class BpfNetMaps {
     public void removeIngressDiscardRule(final InetAddress address) {
         throwIfPreT("removeIngressDiscardRule is not available on pre-T devices");
         try {
-            sIngressDiscardMap.deleteEntry(new IngressDiscardKey(address));
+            if (sIngressDiscardMap != null)
+                sIngressDiscardMap.deleteEntry(new IngressDiscardKey(address));
         } catch (ErrnoException e) {
             Log.e(TAG, "Failed to remove ingress discard rule for " + address + ", " + e);
         }
@@ -955,8 +984,12 @@ public class BpfNetMaps {
         }
 
         try {
-            data.add(mDeps.buildStatsEvent(getMapSize(sCookieTagMap), getMapSize(sUidOwnerMap),
-                    getMapSize(sUidPermissionMap)));
+            if (sUidOwnerMap != null && sCookieTagMap != null && sUidPermissionMap != null) {
+                data.add(mDeps.buildStatsEvent(getMapSize(sCookieTagMap), getMapSize(sUidOwnerMap),
+                        getMapSize(sUidPermissionMap)));
+            } else {
+                return StatsManager.PULL_SKIP;
+            }
         } catch (ErrnoException e) {
             Log.e(TAG, "Failed to pull NETWORK_BPF_MAP_INFO atom: " + e);
             return StatsManager.PULL_SKIP;
@@ -990,8 +1023,10 @@ public class BpfNetMaps {
 
     private void dumpOwnerMatchConfig(final IndentingPrintWriter pw) {
         try {
-            final long match = sConfigurationMap.getValue(UID_RULES_CONFIGURATION_KEY).val;
-            pw.println("current ownerMatch configuration: " + match + " " + matchToString(match));
+            if (sConfigurationMap != null) {
+                final long match = sConfigurationMap.getValue(UID_RULES_CONFIGURATION_KEY).val;
+                pw.println("current ownerMatch configuration: " + match + " " + matchToString(match));
+            }
         } catch (ErrnoException e) {
             pw.println("Failed to read ownerMatch configuration: " + e);
         }
@@ -999,10 +1034,12 @@ public class BpfNetMaps {
 
     private void dumpCurrentStatsMapConfig(final IndentingPrintWriter pw) {
         try {
-            final long config = sConfigurationMap.getValue(CURRENT_STATS_MAP_CONFIGURATION_KEY).val;
-            final String currentStatsMap =
-                    (config == STATS_SELECT_MAP_A) ? "SELECT_MAP_A" : "SELECT_MAP_B";
-            pw.println("current statsMap configuration: " + config + " " + currentStatsMap);
+            if (sConfigurationMap != null) {
+                final long config = sConfigurationMap.getValue(CURRENT_STATS_MAP_CONFIGURATION_KEY).val;
+                final String currentStatsMap =
+                        (config == STATS_SELECT_MAP_A) ? "SELECT_MAP_A" : "SELECT_MAP_B";
+                pw.println("current statsMap configuration: " + config + " " + currentStatsMap);
+            }
         } catch (ErrnoException e) {
             pw.println("Falied to read current statsMap configuration: " + e);
         }
@@ -1010,9 +1047,11 @@ public class BpfNetMaps {
 
     private void dumpDataSaverConfig(final IndentingPrintWriter pw) {
         try {
-            final short config = sDataSaverEnabledMap.getValue(DATA_SAVER_ENABLED_KEY).val;
-            // Any non-zero value converted from short to boolean is true by convention.
-            pw.println("sDataSaverEnabledMap: " + (config != DATA_SAVER_DISABLED));
+            if (sDataSaverEnabledMap != null) {
+                final short config = sDataSaverEnabledMap.getValue(DATA_SAVER_ENABLED_KEY).val;
+                // Any non-zero value converted from short to boolean is true by convention.
+                pw.println("sDataSaverEnabledMap: " + (config != DATA_SAVER_DISABLED));
+            }
         } catch (ErrnoException e) {
             pw.println("Failed to read data saver configuration: " + e);
         }
@@ -1051,25 +1090,34 @@ public class BpfNetMaps {
             // NetworkStatsService also dumps CookieTagMap and NetworkStatsService is a right place
             // to dump CookieTagMap. But the TagSocketTest in CTS depends on this dump so the tests
             // need to be updated before remove the dump from BpfNetMaps.
-            BpfDump.dumpMap(sCookieTagMap, pw, "sCookieTagMap",
-                    (key, value) -> "cookie=" + key.socketCookie
-                            + " tag=0x" + Long.toHexString(value.tag)
-                            + " uid=" + value.uid);
-            BpfDump.dumpMap(sUidOwnerMap, pw, "sUidOwnerMap",
-                    (uid, match) -> {
-                        if ((match.rule & IIF_MATCH) != 0) {
-                            // TODO: convert interface index to interface name by IfaceIndexNameMap
-                            return uid.val + " " + matchToString(match.rule) + " " + match.iif;
-                        } else {
-                            return uid.val + " " + matchToString(match.rule);
-                        }
-                    });
-            BpfDump.dumpMap(sUidPermissionMap, pw, "sUidPermissionMap",
-                    (uid, permission) -> uid.val + " " + permissionToString(permission.val));
-            BpfDump.dumpMap(sIngressDiscardMap, pw, "sIngressDiscardMap",
-                    (key, value) -> "[" + key.dstAddr + "]: "
-                            + value.iif1 + "(" + mDeps.getIfName(value.iif1) + "), "
-                            + value.iif2 + "(" + mDeps.getIfName(value.iif2) + ")");
+            if (sCookieTagMap != null) {
+                BpfDump.dumpMap(sCookieTagMap, pw, "sCookieTagMap",
+                        (key, value) -> "cookie=" + key.socketCookie
+                                + " tag=0x" + Long.toHexString(value.tag)
+                                + " uid=" + value.uid);
+            }
+
+            if (sUidOwnerMap != null) {
+                BpfDump.dumpMap(sUidOwnerMap, pw, "sUidOwnerMap",
+                        (uid, match) -> {
+                            if ((match.rule & IIF_MATCH) != 0) {
+                                // TODO: convert interface index to interface name by IfaceIndexNameMap
+                                return uid.val + " " + matchToString(match.rule) + " " + match.iif;
+                            } else {
+                                return uid.val + " " + matchToString(match.rule);
+                            }
+                        });
+            }
+            if (sUidPermissionMap != null) {
+                BpfDump.dumpMap(sUidPermissionMap, pw, "sUidPermissionMap",
+                        (uid, permission) -> uid.val + " " + permissionToString(permission.val));
+            }
+            if (sIngressDiscardMap != null) {
+                BpfDump.dumpMap(sIngressDiscardMap, pw, "sIngressDiscardMap",
+                        (key, value) -> "[" + key.dstAddr + "]: "
+                                + value.iif1 + "(" + mDeps.getIfName(value.iif1) + "), "
+                                + value.iif2 + "(" + mDeps.getIfName(value.iif2) + ")");
+            }
             dumpDataSaverConfig(pw);
             pw.decreaseIndent();
         }


### PR DESCRIPTION
Tested under ProjectSakura with TD-r37 patches. Fixed 4.14 boot issues related to bpf like:

--------- beginning of crash
05-20 01:00:19.948  2165  2165 E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: main
05-20 01:00:19.948  2165  2165 E AndroidRuntime: java.lang.RuntimeException: Failed to create service com.android.server.ConnectivityServiceInitializer: service constructor threw an exception
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServiceManager.startService(SystemServiceManager.java:229)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServiceManager.startServiceFromJar(SystemServiceManager.java:155)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:2120)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServer.run(SystemServer.java:968)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServer.main(SystemServer.java:689)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:555)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:856)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: Caused by: java.lang.reflect.InvocationTargetException
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at java.lang.reflect.Constructor.newInstance0(Native Method)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.SystemServiceManager.startService(SystemServiceManager.java:218)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	... 7 more
05-20 01:00:19.948  2165  2165 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke interface method 'android.net.connectivity.com.android.net.module.util.Struct android.net.connectivity.com.android.net.module.util.IBpfMap.getValue(android.net.connectivity.com.android.net.module.util.Struct)' on a null object reference
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at android.net.connectivity.com.android.server.BpfNetMaps.setChildChain(BpfNetMaps.java:516)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at android.net.connectivity.com.android.server.ConnectivityService.<init>(ConnectivityService.java:2066)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at android.net.connectivity.com.android.server.ConnectivityService.<init>(ConnectivityService.java:1963)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	at com.android.server.ConnectivityServiceInitializer.<init>(ConnectivityServiceInitializer.java:52)
05-20 01:00:19.948  2165  2165 E AndroidRuntime: 	... 10 more